### PR TITLE
Fix default colors loading

### DIFF
--- a/autoload/glyph_palette/defaults.vim
+++ b/autoload/glyph_palette/defaults.vim
@@ -18,6 +18,9 @@ let g:glyph_palette#defaults#palette = {
 " The following default colors are copied from iceberg.vim
 " REF: https://github.com/cocopon/iceberg.vim
 " MIT: Copyright (c) 2014 cocopon <cocopon@me.com>
+"
+" NOTE:
+" Use glyph_palette#tools#print_colors(colors) function to modify the following variable
 let g:glyph_palette#defaults#colors = {
       \ 'light': [
       \   '#dcdfe7',

--- a/autoload/glyph_palette/tools.vim
+++ b/autoload/glyph_palette/tools.vim
@@ -54,11 +54,15 @@ function! glyph_palette#tools#show_palette(...) abort
 endfunction
 
 function! s:print_colors(colors) abort
+  let indent = repeat(' ', 6)
+  echo 'let s:colors = {'
+  echo indent . '\ ''__type__'': ['
   let ps = map(copy(a:colors), { k, v -> ['GlyphPalette' . k, k, v] })
-  let es = map(ps, { -> call('printf', ['highlight %s ctermfg=%s guifg=%s'] + v:val) })
-  for expr in es
-    echo expr
+  for color in a:colors
+    echo indent . printf('\   ''%s'',', color)
   endfor
+  echo indent . '\ ],'
+  echo indent . '\}'
 endfunction
 
 function! s:print_palette(palette) abort


### PR DESCRIPTION
Fixed to be referenced when `g:terminal_ansi_colors` or `g:terminal_color_0` is defained after this plugin is loaded.